### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ For questions, bug reports, or feature requests, please open an issue on the pro
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=gausian-AI/Gausian_native_editor&type=date&legend=top-left)](https://www.star-history.com/#gausian-AI/Gausian_native_editor&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=gausian-AI/Gausian_native_editor&type=date&legend=top-left)](https://star-history.dera.page/#gausian-AI/Gausian_native_editor&type=date&legend=top-left)
 
 **Built with ❤️ in Rust** | **GPU-Accelerated** | **Cross-Platform** | **Open Source**
 


### PR DESCRIPTION
The star history chart on the README is currently broken because of GitHub stargazer API restrictions. This change points it at a working replacement so the chart renders again.